### PR TITLE
sugar-measure-activity_51.1~quozl1 uploaded

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+sugar-measure-activity (51-1~quozl1) trusty; urgency=medium
+
+  * add missing GStreamer ALSA dependency
+
+ -- James Cameron <quozl@laptop.org>  Wed, 27 May 2015 13:50:42 +1000
+
 sugar-measure-activity (51-0tch2) UNRELEASED; urgency=low
 
   * Add missing gstreamer0.10-plugins-good dependency.

--- a/debian/rules
+++ b/debian/rules
@@ -43,7 +43,7 @@ DEB_COPYRIGHT_CHECK_IGNORE_REGEX = ^data/logo_.*\.png|debian/(changelog|copyrigh
 
 # Needed (always/often/seldom) at runtime
 python-deps = gobject gtk2 cairo gst0.10 sugar-0.98 sugar-toolkit-0.98
-CDBS_DEPENDS_$(pkg) = python, csound, gstreamer0.10-plugins-good
+CDBS_DEPENDS_$(pkg) = python, csound, gstreamer0.10-plugins-good, gstreamer0.10-alsa
 CDBS_DEPENDS_$(pkg) +=, $(patsubst %,$(comma) python-%,$(python-deps))
 CDBS_RECOMMENDS_$(pkg) = sugar-$(DEB_SUGAR_PRIMARY_BRANCH)-icon-theme | sugar-icon-theme | sugar-artwork
 


### PR DESCRIPTION
Add missing dependency, and uploaded new package.

Only affected Debian Stretch.

On Ubuntu Trusty there is a dependency on _gstreamer0.10-alsa_ by _ubuntu-desktop_.
